### PR TITLE
added Bazel Workspace so you can target the Github repository directly

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,6 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
+proto_library(
+      name = "openvectorformat",
+      srcs = ["open_vector_format.proto"],
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,14 @@
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "rules_proto",
+    sha256 = "602e7161d9195e50246177e7c55b2f39950a9cf7366f74ed5f22fd45750cd208",
+    strip_prefix = "rules_proto-97d8af4dc474595af3900dd85cb3a29ad28cc313",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+        "https://github.com/bazelbuild/rules_proto/archive/97d8af4dc474595af3900dd85cb3a29ad28cc313.tar.gz",
+    ],
+)
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()


### PR DESCRIPTION
added a simple Bazel Workspace, so you can include it into other projects by the "git-repository" rule.